### PR TITLE
Messagepack with node-gyp

### DIFF
--- a/lib/stagger/protocol.js
+++ b/lib/stagger/protocol.js
@@ -1,7 +1,7 @@
 var events = require('events');
 var util = require('util');
 
-var msgpack = require('msgpack2');
+var msgpack = require('msgpack');
 
 var PairRegistration = require('../pair/registration');
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index",
   "dependencies": {
     "async": "0.2.9",
-    "msgpack2": "0.1.7",
+    "msgpack2": "git+ssh://git@github.com:pgriess/node-msgpack.git#8398fa2bc65abfb87e82ba9f641635b2dd36f617",
     "zmq": "2.5.1"
   }
 }


### PR DESCRIPTION
Upgrade messagepack node libraries to one compatible with node-gyp, which is required for node 0.10. Unfortunately, this means using a git version.
