### PR TITLE
remove msgpack2 and exchange with msgpack-lite which is a pure js implementation of msgpack.

### DIFF
--- a/lib/protocol/encoder.js
+++ b/lib/protocol/encoder.js
@@ -1,4 +1,4 @@
-var msgpack = require('msgpack2');
+var msgpack = require('msgpack-lite');
 
 var constants = require('./constants');
 

--- a/lib/protocol/parser.js
+++ b/lib/protocol/parser.js
@@ -1,5 +1,5 @@
 var events = require("events");
-var msgpack = require('msgpack2');
+var msgpack = require('msgpack-lite');
 var util = require("util");
 
 var constants = require('./constants');

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "main": "index",
   "dependencies": {
     "async": "0.2.9",
-    "msgpack2": "0.1.7"
+    "msgpack-lite": "0.1.13"
   }
 }


### PR DESCRIPTION
`msgpack2` no longer builds on node v0.10+
`msgpack` will not build correctly on ubuntu without a c++2011 compiler.
... so, msgpack-lite is a js implementation of the protocol: same output, 5x slower pack/unpack compared to JSON.stringify/parse which is reasonable given that the latter is optimized c code.

CC @pl @zimbatm 
